### PR TITLE
Patch to IoC-267

### DIFF
--- a/src/Castle.Windsor.Tests/Bugs/IoC-267.cs
+++ b/src/Castle.Windsor.Tests/Bugs/IoC-267.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Castle.Bugs
+{
+    using Castle.MicroKernel;
+    using Castle.MicroKernel.Registration;
+
+    using NUnit.Framework;
+
+    [TestFixture]
+    public class IoC_267
+    {
+        [Test]
+        public void When_attemting_to_resolve_component_with_nonpublic_ctor_should_throw_meaningfull_exception()
+        {
+            var kernel = new DefaultKernel();
+
+            
+            kernel.Register(Component.For<Int32>());
+        }
+    }
+}

--- a/src/Castle.Windsor.Tests/Bugs/IoC-267.cs
+++ b/src/Castle.Windsor.Tests/Bugs/IoC-267.cs
@@ -1,25 +1,40 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-
-namespace Castle.Bugs
+﻿namespace Castle.Bugs
 {
-    using Castle.MicroKernel;
-    using Castle.MicroKernel.Registration;
+    using System;
+    using System.CodeDom.Compiler;
+    using System.Linq;
 
+    using Castle.MicroKernel;
+    using Microsoft.CSharp;
     using NUnit.Framework;
 
     [TestFixture]
     public class IoC_267
     {
         [Test]
-        public void When_attemting_to_resolve_component_with_nonpublic_ctor_should_throw_meaningfull_exception()
+        public void When_attemting_to_register_component_descended_from_valuetype_should_not_compile()
         {
-            var kernel = new DefaultKernel();
+            var csharpCode = @"
+                                using System;
+                                using Castle.MicroKernel;
+                                using Castle.MicroKernel.Registration;
 
-            
-            kernel.Register(Component.For<Int32>());
+                                public class ShouldNotCompile 
+                                {
+                                    public void MethodContainsInvalidCode()
+                                    {
+                                        var kernel = new DefaultKernel();
+                                        kernel.Register(Component.For<Int32>().Instance(1));
+                                    }
+                                }
+                                ";
+
+            var compiler = new CSharpCodeProvider();
+            var coreAssembly = AppDomain.CurrentDomain.GetAssemblies().Single(a => a.GetName().Name == "Castle.Core").Location;
+            var windsorAssembly = typeof(DefaultKernel).Assembly.Location;
+            var results = compiler.CompileAssemblyFromSource(new CompilerParameters(new[] { coreAssembly, windsorAssembly }), csharpCode);
+            Assert.True(results.Errors.HasErrors);
+            Assert.AreEqual("CS0452", results.Errors[0].ErrorNumber); // The type 'int' must be a reference type in order to use it as parameter 'S' in the generic type or method 'Castle.MicroKernel.Registration.Component.For<S>()'
         }
     }
 }

--- a/src/Castle.Windsor.Tests/Castle.Windsor.Tests.csproj
+++ b/src/Castle.Windsor.Tests/Castle.Windsor.Tests.csproj
@@ -302,6 +302,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="AbstractContainerTestFixture.cs" />
+    <Compile Include="Bugs\IoC-267.cs" />
     <Compile Include="ByRefDependenciesTestCase.cs" />
     <Compile Include="ClassComponents\CBA.cs" />
     <Compile Include="ClassComponents\GenericHasNested.cs" />

--- a/src/Castle.Windsor.Tests/Experimental/ReleasePolicyTrackedObjectsTestCase.cs
+++ b/src/Castle.Windsor.Tests/Experimental/ReleasePolicyTrackedObjectsTestCase.cs
@@ -120,7 +120,8 @@ namespace Castle.Windsor.Tests.Experimental
 			return subSystem.SelectMany(e => e.Attach()).SingleOrDefault(i => i.Name == ReleasePolicyTrackedObjects.Name);
 		}
 
-		private void Register<T>()
+        private void Register<T>()
+            where T : class 
 		{
 			Container.Register(Component.For<T>().LifeStyle.Transient);
 		}

--- a/src/Castle.Windsor.Tests/Facilities/Startable/StartableFacilityTestCase.cs
+++ b/src/Castle.Windsor.Tests/Facilities/Startable/StartableFacilityTestCase.cs
@@ -303,7 +303,8 @@ namespace Castle.Windsor.Tests.Facilities.Startable
 		}
 	}
 
-	public class AddDependency<T> : ComponentDescriptor<T>
+    public class AddDependency<T> : ComponentDescriptor<T>
+            where T : class 
 	{
 		private readonly DependencyModel dependency;
 

--- a/src/Castle.Windsor.Tests/HandlerExtensionsTestCase.cs
+++ b/src/Castle.Windsor.Tests/HandlerExtensionsTestCase.cs
@@ -39,7 +39,8 @@ namespace Castle.Windsor.Tests
 		}
 
 		private ComponentRegistration<TComponent> WithReleaseExtensions<TComponent>(
-			ComponentRegistration<TComponent> componentRegistration, params IReleaseExtension[] items)
+			ComponentRegistration<TComponent> componentRegistration, params IReleaseExtension[] items) 
+            where TComponent : class
 		{
 			var releaseExtensions = new List<IReleaseExtension>();
 			foreach (var item in items.Distinct())

--- a/src/Castle.Windsor.Tests/LifecycledComponentsReleasePolicyTestCase.cs
+++ b/src/Castle.Windsor.Tests/LifecycledComponentsReleasePolicyTestCase.cs
@@ -181,15 +181,18 @@ namespace Castle.Windsor.Tests
 		}
 
 		private ComponentRegistration<T> Transient<T>()
+            where T : class 
 		{
 			return Component.For<T>().LifeStyle.Transient;
 		}
 
 		private ComponentRegistration<T> Pooled<T>()
+            where T : class 
 		{
 			return Component.For<T>().LifeStyle.Pooled;
 		}
-		private ComponentRegistration<T> Singleton<T>()
+        private ComponentRegistration<T> Singleton<T>()
+            where T : class 
 		{
 			return Component.For<T>().LifeStyle.Singleton;
 		}

--- a/src/Castle.Windsor.Tests/Registration/Interceptors/InterceptorsTestCaseHelper.cs
+++ b/src/Castle.Windsor.Tests/Registration/Interceptors/InterceptorsTestCaseHelper.cs
@@ -21,7 +21,7 @@ namespace Castle.MicroKernel.Tests.Registration.Interceptors
 
 	public abstract class InterceptorsTestCaseHelper
 	{
-		public abstract IRegistration RegisterInterceptors<T>(ComponentRegistration<T> registration);
+		public abstract IRegistration RegisterInterceptors<T>(ComponentRegistration<T> registration) where T : class;
 
 		public abstract IEnumerable<InterceptorReference> GetExpectedInterceptorsInCorrectOrder();
 	}

--- a/src/Castle.Windsor/Facilities/EventWiring/EventWiringDescriptor.cs
+++ b/src/Castle.Windsor/Facilities/EventWiring/EventWiringDescriptor.cs
@@ -19,7 +19,8 @@ namespace Castle.Facilities.EventWiring
 	using Castle.MicroKernel.Registration;
 
 
-	public class EventWiringDescriptor<T> : ComponentDescriptor<T>
+    public class EventWiringDescriptor<T> : ComponentDescriptor<T>
+        where T : class 
 	{
 		private readonly string eventName;
 		private readonly EventSubscriber[] subscribers;

--- a/src/Castle.Windsor/Facilities/EventWiring/EventWiringRegistrationExtensions.cs
+++ b/src/Castle.Windsor/Facilities/EventWiring/EventWiringRegistrationExtensions.cs
@@ -22,7 +22,8 @@ namespace Castle.Facilities.EventWiring
 	public static class EventWiringRegistrationExtensions
 	{
 #if !SILVERLIGHT
-		public static ComponentRegistration<TPublisher> PublishEvent<TPublisher>(this ComponentRegistration<TPublisher> registration, Action<TPublisher> eventSubscribtion, Action<EventSubscribers> toSubscribers)
+        public static ComponentRegistration<TPublisher> PublishEvent<TPublisher>(this ComponentRegistration<TPublisher> registration, Action<TPublisher> eventSubscribtion, Action<EventSubscribers> toSubscribers)
+            where TPublisher : class 
 		{
 			var eventName = GetEventName(eventSubscribtion);
 
@@ -43,7 +44,8 @@ namespace Castle.Facilities.EventWiring
 			return registration;
 		}
 #endif
-		public static ComponentRegistration<TPublisher> PublishEvent<TPublisher>(this ComponentRegistration<TPublisher> registration, string eventName, Action<EventSubscribers> toSubscribers)
+        public static ComponentRegistration<TPublisher> PublishEvent<TPublisher>(this ComponentRegistration<TPublisher> registration, string eventName, Action<EventSubscribers> toSubscribers)
+            where TPublisher : class 
 		{
 			var subscribers = new EventSubscribers();
 			toSubscribers(subscribers);

--- a/src/Castle.Windsor/Facilities/Startable/StartableFacilityRegistrationExtensions.cs
+++ b/src/Castle.Windsor/Facilities/Startable/StartableFacilityRegistrationExtensions.cs
@@ -23,7 +23,8 @@ namespace Castle.Facilities.Startable
 
 	public static class StartableFacilityRegistrationExtensions
 	{
-		public static ComponentRegistration<TService> Start<TService>(this ComponentRegistration<TService> registration)
+        public static ComponentRegistration<TService> Start<TService>(this ComponentRegistration<TService> registration)
+            where TService : class 
 		{
 			return registration.AddAttributeDescriptor("startable", true.ToString());
 		}
@@ -37,7 +38,8 @@ namespace Castle.Facilities.Startable
 		/// <remarks>Be sure that you first added the <see cref="Castle.Facilities.Startable.StartableFacility"/> 
 		/// to the kernel, before registering this component.</remarks>
 		public static ComponentRegistration<TService> StartUsingMethod<TService>(
-			this ComponentRegistration<TService> registration, string startMethod)
+            this ComponentRegistration<TService> registration, string startMethod)
+            where TService : class 
 		{
 			return Start(registration)
 				.AddAttributeDescriptor("startMethod", startMethod);
@@ -52,7 +54,8 @@ namespace Castle.Facilities.Startable
 		/// <remarks>Be sure that you first added the <see cref="Castle.Facilities.Startable.StartableFacility"/> 
 		/// to the kernel, before registering this component.</remarks>
 		public static ComponentRegistration<TService> StartUsingMethod<TService>(
-			this ComponentRegistration<TService> registration, Expression<Func<TService, Action>> methodToUse)
+            this ComponentRegistration<TService> registration, Expression<Func<TService, Action>> methodToUse)
+            where TService : class 
 		{
 			var startMethod = ObtainMethodName(methodToUse);
 			return Start(registration)
@@ -68,7 +71,8 @@ namespace Castle.Facilities.Startable
 		/// <remarks>Be sure that you first added the <see cref="Castle.Facilities.Startable.StartableFacility"/> 
 		/// to the kernel, before registering this component.</remarks>
 		public static ComponentRegistration<TService> StopUsingMethod<TService>(
-			this ComponentRegistration<TService> registration, string stopMethod)
+            this ComponentRegistration<TService> registration, string stopMethod)
+            where TService : class 
 		{
 			return Start(registration)
 				.AddAttributeDescriptor("stopMethod", stopMethod);
@@ -83,7 +87,8 @@ namespace Castle.Facilities.Startable
 		/// <remarks>Be sure that you first added the <see cref="Castle.Facilities.Startable.StartableFacility"/> 
 		/// to the kernel, before registering this component.</remarks>
 		public static ComponentRegistration<TService> StopUsingMethod<TService>(
-			this ComponentRegistration<TService> registration, Expression<Func<TService, Action>> methodToUse)
+            this ComponentRegistration<TService> registration, Expression<Func<TService, Action>> methodToUse)
+            where TService : class 
 		{
 			var stopMethod = ObtainMethodName(methodToUse);
 			;

--- a/src/Castle.Windsor/Facilities/TypedFactory/FactoryCacheDescriptor.cs
+++ b/src/Castle.Windsor/Facilities/TypedFactory/FactoryCacheDescriptor.cs
@@ -18,7 +18,8 @@ namespace Castle.Facilities.TypedFactory
 	using Castle.MicroKernel;
 	using Castle.MicroKernel.Registration;
 
-	public class FactoryCacheDescriptor<TFactory> : ComponentDescriptor<TFactory>
+    public class FactoryCacheDescriptor<TFactory> : ComponentDescriptor<TFactory>
+        where TFactory : class 
 	{
 		private readonly TypedFactoryCachingInspector cacheBuilder = new TypedFactoryCachingInspector();
 

--- a/src/Castle.Windsor/Facilities/TypedFactory/TypedFactoryRegistrationExtensions.cs
+++ b/src/Castle.Windsor/Facilities/TypedFactory/TypedFactoryRegistrationExtensions.cs
@@ -38,7 +38,8 @@ namespace Castle.Facilities.TypedFactory
 		///   Typed factories rely on <see cref = "IInterceptorSelector" /> set internally, so users should not set interceptor selectors explicitly;
 		///   otherwise the factory will not function correctly.
 		/// </remarks>
-		public static ComponentRegistration<TFactoryInterface> AsFactory<TFactoryInterface>(this ComponentRegistration<TFactoryInterface> registration)
+        public static ComponentRegistration<TFactoryInterface> AsFactory<TFactoryInterface>(this ComponentRegistration<TFactoryInterface> registration)
+            where TFactoryInterface : class 
 		{
 			return AsFactory(registration, null);
 		}
@@ -57,7 +58,8 @@ namespace Castle.Facilities.TypedFactory
 		///   otherwise the factory will not function correctly.
 		/// </remarks>
 		public static ComponentRegistration<TFactoryInterface> AsFactory<TFactoryInterface>(this ComponentRegistration<TFactoryInterface> registration,
-		                                                                                    Action<TypedFactoryConfiguration> configuration)
+                                                                                            Action<TypedFactoryConfiguration> configuration)
+            where TFactoryInterface : class 
 		{
 			if (registration == null)
 			{
@@ -95,7 +97,8 @@ namespace Castle.Facilities.TypedFactory
 
 		private static ComponentRegistration<TFactory> AttachConfiguration<TFactory>(ComponentRegistration<TFactory> componentRegistration,
 		                                                                             Action<TypedFactoryConfiguration> configuration,
-		                                                                             string defaultComponentSelectorKey)
+                                                                                     string defaultComponentSelectorKey)
+            where TFactory : class 
 		{
 			var selectorReference = GetSelectorReference(configuration, defaultComponentSelectorKey);
 			componentRegistration.AddDescriptor(new ReferenceDependencyDescriptor<TFactory>(selectorReference));
@@ -116,6 +119,7 @@ namespace Castle.Facilities.TypedFactory
 		}
 
 		private static ComponentRegistration<TFactory> AttachFactoryInterceptor<TFactory>(ComponentRegistration<TFactory> registration)
+            where TFactory : class 
 		{
 			return registration.Interceptors(new InterceptorReference(TypedFactoryFacility.InterceptorKey)).Last;
 		}
@@ -138,6 +142,7 @@ namespace Castle.Facilities.TypedFactory
 		}
 
 		private static bool IsAnyServiceOpenGeneric<TFactory>(ComponentRegistration<TFactory> componentRegistration)
+            where TFactory : class 
 		{
 			if (componentRegistration.Services.Any(i => i.ContainsGenericParameters))
 			{
@@ -148,6 +153,7 @@ namespace Castle.Facilities.TypedFactory
 
 		private static ComponentRegistration<TDelegate> RegisterDelegateBasedFactory<TDelegate>(ComponentRegistration<TDelegate> registration,
 		                                                                                        Action<TypedFactoryConfiguration> configuration, Type delegateType)
+            where TDelegate : class 
 		{
 			if (HasOutArguments(delegateType))
 			{
@@ -182,7 +188,8 @@ namespace Castle.Facilities.TypedFactory
 		}
 
 		private static ComponentRegistration<TFactoryInterface> RegisterInterfaceBasedFactory<TFactoryInterface>(
-			ComponentRegistration<TFactoryInterface> registration, Action<TypedFactoryConfiguration> configuration)
+            ComponentRegistration<TFactoryInterface> registration, Action<TypedFactoryConfiguration> configuration)
+            where TFactoryInterface : class 
 		{
 			foreach (var serviceType in registration.Services)
 			{

--- a/src/Castle.Windsor/MicroKernel/Registration/AbstractPropertyDescriptor.cs
+++ b/src/Castle.Windsor/MicroKernel/Registration/AbstractPropertyDescriptor.cs
@@ -17,7 +17,8 @@ namespace Castle.MicroKernel.Registration
 	using System.Collections;
 	using Core;
 
-	public abstract class AbstractPropertyDescriptor<S> : ComponentDescriptor<S>
+    public abstract class AbstractPropertyDescriptor<S> : ComponentDescriptor<S>
+        where S : class 
 	{
 		private readonly Property[] properties;
 		private readonly IDictionary dictionary;

--- a/src/Castle.Windsor/MicroKernel/Registration/AttributeDescriptor.cs
+++ b/src/Castle.Windsor/MicroKernel/Registration/AttributeDescriptor.cs
@@ -17,7 +17,8 @@ namespace Castle.MicroKernel.Registration
 	using System;
 	using Castle.Core.Configuration;
 
-	public class AttributeDescriptor<S> : ComponentDescriptor<S>
+    public class AttributeDescriptor<S> : ComponentDescriptor<S>
+        where S : class 
 	{
 		private readonly String name;
 		private readonly String value;
@@ -43,6 +44,7 @@ namespace Castle.MicroKernel.Registration
 	}
 
 	public class AttributeKeyDescriptor<S>
+            where S : class 
 	{
 		private readonly String name;
 		private readonly ComponentRegistration<S> component;

--- a/src/Castle.Windsor/MicroKernel/Registration/Component.cs
+++ b/src/Castle.Windsor/MicroKernel/Registration/Component.cs
@@ -89,7 +89,8 @@ namespace Castle.MicroKernel.Registration
 		/// </summary>
 		/// <typeparam name="S">The service type.</typeparam>
 		/// <returns>The component registration.</returns>
-		public static ComponentRegistration<S> For<S>()
+        public static ComponentRegistration<S> For<S>()
+            where S : class 
 		{
 			return new ComponentRegistration<S>();
 		}
@@ -204,7 +205,8 @@ namespace Castle.MicroKernel.Registration
 		/// <typeparam name="S">The primary service type.</typeparam>
 		/// <typeparam name="F">The forwarded type.</typeparam>
 		/// <returns>The component registration.</returns>
-		public static ComponentRegistration<S> For<S, F>()
+        public static ComponentRegistration<S> For<S, F>()
+            where S : class 
 		{
 			return new ComponentRegistration<S>().Forward<F>();
 		}
@@ -216,7 +218,8 @@ namespace Castle.MicroKernel.Registration
 		/// <typeparam name="F1">The first forwarded type.</typeparam>
 		/// <typeparam name="F2">The second forwarded type.</typeparam>
 		/// <returns>The component registration.</returns>
-		public static ComponentRegistration<S> For<S, F1, F2>()
+        public static ComponentRegistration<S> For<S, F1, F2>()
+            where S : class 
 		{
 			return new ComponentRegistration<S>().Forward<F1, F2>();
 		}
@@ -229,7 +232,8 @@ namespace Castle.MicroKernel.Registration
 		/// <typeparam name="F2">The second forwarded type.</typeparam>
 		/// <typeparam name="F3">The third forwarded type.</typeparam>
 		/// <returns>The component registration.</returns>
-		public static ComponentRegistration<S> For<S, F1, F2, F3>()
+        public static ComponentRegistration<S> For<S, F1, F2, F3>()
+            where S : class 
 		{
 			return new ComponentRegistration<S>().Forward<F1, F2, F3>();
 		}
@@ -243,7 +247,8 @@ namespace Castle.MicroKernel.Registration
 		/// <typeparam name="F3">The third forwarded type.</typeparam>
 		/// <typeparam name="F4">The fourth forwarded type.</typeparam>
 		/// <returns>The component registration.</returns>
-		public static ComponentRegistration<S> For<S, F1, F2, F3, F4>()
+        public static ComponentRegistration<S> For<S, F1, F2, F3, F4>()
+            where S : class 
 		{
 			return new ComponentRegistration<S>().Forward<F1, F2, F3, F4>();
 		}

--- a/src/Castle.Windsor/MicroKernel/Registration/ComponentDescriptor.cs
+++ b/src/Castle.Windsor/MicroKernel/Registration/ComponentDescriptor.cs
@@ -17,7 +17,8 @@ namespace Castle.MicroKernel.Registration
 	using Castle.Core;
 	using Castle.Core.Configuration;
 
-	public abstract class ComponentDescriptor<S>
+    public abstract class ComponentDescriptor<S>
+        where S : class 
 	{
 		private ComponentRegistration<S> registration;
 

--- a/src/Castle.Windsor/MicroKernel/Registration/ComponentRegistration.cs
+++ b/src/Castle.Windsor/MicroKernel/Registration/ComponentRegistration.cs
@@ -40,6 +40,7 @@ namespace Castle.MicroKernel.Registration
 	/// </summary>
 	/// <typeparam name = "TService">The service type</typeparam>
 	public class ComponentRegistration<TService> : IRegistration
+        where TService : class 
 	{
 		private readonly List<ComponentDescriptor<TService>> descriptors = new List<ComponentDescriptor<TService>>();
 		private readonly List<Type> potentialServices = new List<Type>();

--- a/src/Castle.Windsor/MicroKernel/Registration/ConfigurationDescriptor.cs
+++ b/src/Castle.Windsor/MicroKernel/Registration/ConfigurationDescriptor.cs
@@ -16,7 +16,8 @@ namespace Castle.MicroKernel.Registration
 {
 	using Castle.Core.Configuration;
 
-	public class ConfigurationDescriptor<S> : ComponentDescriptor<S>
+    public class ConfigurationDescriptor<S> : ComponentDescriptor<S>
+        where S : class 
 	{
 		private readonly IConfiguration configuration;
 		private readonly Node[] configNodes;

--- a/src/Castle.Windsor/MicroKernel/Registration/CustomDependencyDescriptor.cs
+++ b/src/Castle.Windsor/MicroKernel/Registration/CustomDependencyDescriptor.cs
@@ -17,7 +17,8 @@ namespace Castle.MicroKernel.Registration
 	using System.Collections;
 	using Castle.Core;
 
-	public class CustomDependencyDescriptor<S> : AbstractPropertyDescriptor<S>
+    public class CustomDependencyDescriptor<S> : AbstractPropertyDescriptor<S>
+        where S : class 
 	{
 		public CustomDependencyDescriptor(params Property[] properties)
 			: base(properties)

--- a/src/Castle.Windsor/MicroKernel/Registration/DependencyDescriptor.cs
+++ b/src/Castle.Windsor/MicroKernel/Registration/DependencyDescriptor.cs
@@ -16,7 +16,8 @@ namespace Castle.MicroKernel.Registration
 {
 	using Castle.Core;
 
-	public class ReferenceDependencyDescriptor<S> : ComponentDescriptor<S>
+    public class ReferenceDependencyDescriptor<S> : ComponentDescriptor<S>
+        where S : class 
 	{
 		private readonly IReference<object> dependency;
 

--- a/src/Castle.Windsor/MicroKernel/Registration/DynamicParametersDescriptor.cs
+++ b/src/Castle.Windsor/MicroKernel/Registration/DynamicParametersDescriptor.cs
@@ -27,7 +27,8 @@ namespace Castle.MicroKernel.Registration
 
 	public delegate ComponentReleasingDelegate DynamicParametersResolveDelegate(IKernel kernel, IDictionary parameters);
 
-	public class DynamicParametersDescriptor<S> : ComponentDescriptor<S>
+    public class DynamicParametersDescriptor<S> : ComponentDescriptor<S>
+            where S : class 
 	{
 		private readonly DynamicParametersWithContextResolveDelegate resolve;
 		private static readonly string key = "component_resolving_handler";

--- a/src/Castle.Windsor/MicroKernel/Registration/ExtendedPropertiesDescriptor.cs
+++ b/src/Castle.Windsor/MicroKernel/Registration/ExtendedPropertiesDescriptor.cs
@@ -17,7 +17,8 @@ namespace Castle.MicroKernel.Registration
 	using System.Collections;
 	using Castle.Core;
 
-	public class ExtendedPropertiesDescriptor<S> : AbstractPropertyDescriptor<S>
+    public class ExtendedPropertiesDescriptor<S> : AbstractPropertyDescriptor<S>
+        where S : class 
 	{
 		public ExtendedPropertiesDescriptor(params Property[] properties)
 			: base(properties)

--- a/src/Castle.Windsor/MicroKernel/Registration/Interceptor/InterceptorDescriptor.cs
+++ b/src/Castle.Windsor/MicroKernel/Registration/Interceptor/InterceptorDescriptor.cs
@@ -17,7 +17,8 @@ namespace Castle.MicroKernel.Registration.Interceptor
 	using System;
 	using Castle.Core;
 
-	public class InterceptorDescriptor<S> : ComponentDescriptor<S>
+    public class InterceptorDescriptor<S> : ComponentDescriptor<S>
+        where S : class 
 	{
 		private readonly Where where;
 		private readonly int insertIndex;

--- a/src/Castle.Windsor/MicroKernel/Registration/Interceptor/InterceptorGroup.cs
+++ b/src/Castle.Windsor/MicroKernel/Registration/Interceptor/InterceptorGroup.cs
@@ -18,7 +18,8 @@ namespace Castle.MicroKernel.Registration.Interceptor
 
 	using Core;
 
-	public class InterceptorGroup<S> : RegistrationGroup<S>
+    public class InterceptorGroup<S> : RegistrationGroup<S>
+        where S : class 
 	{
 		private readonly InterceptorReference[] interceptors;
 

--- a/src/Castle.Windsor/MicroKernel/Registration/Interceptor/InterceptorSelectorDescriptor.cs
+++ b/src/Castle.Windsor/MicroKernel/Registration/Interceptor/InterceptorSelectorDescriptor.cs
@@ -18,7 +18,8 @@ namespace Castle.MicroKernel.Registration.Interceptor
 	using Castle.DynamicProxy;
 	using Castle.MicroKernel.Proxy;
 
-	public class InterceptorSelectorDescriptor<S> : ComponentDescriptor<S>
+    public class InterceptorSelectorDescriptor<S> : ComponentDescriptor<S>
+        where S : class 
 	{
 		private readonly IReference<IInterceptorSelector> selector;
 

--- a/src/Castle.Windsor/MicroKernel/Registration/Lifestyle/LifestyleGroup.cs
+++ b/src/Castle.Windsor/MicroKernel/Registration/Lifestyle/LifestyleGroup.cs
@@ -18,7 +18,8 @@ namespace Castle.MicroKernel.Registration.Lifestyle
 	using Castle.Core;
 	using Castle.Core.Internal;
 
-	public class LifestyleGroup<S> : RegistrationGroup<S>
+    public class LifestyleGroup<S> : RegistrationGroup<S>
+        where S : class 
 	{
 		public LifestyleGroup(ComponentRegistration<S> registration)
 			: base(registration)

--- a/src/Castle.Windsor/MicroKernel/Registration/LifestyleDescriptor.cs
+++ b/src/Castle.Windsor/MicroKernel/Registration/LifestyleDescriptor.cs
@@ -17,7 +17,8 @@ namespace Castle.MicroKernel.Registration
 	using Castle.Core;
 	using Castle.Core.Configuration;
 
-	public class LifestyleDescriptor<S> : ComponentDescriptor<S>
+    public class LifestyleDescriptor<S> : ComponentDescriptor<S>
+        where S : class 
 	{
 		private readonly LifestyleType lifestyle;
 

--- a/src/Castle.Windsor/MicroKernel/Registration/OnCreateComponentDescriptor.cs
+++ b/src/Castle.Windsor/MicroKernel/Registration/OnCreateComponentDescriptor.cs
@@ -21,7 +21,8 @@ namespace Castle.MicroKernel.Registration
 	/// Adds the actions to ExtendedProperties.
 	/// </summary>
 	/// <typeparam name="S"></typeparam>
-	public class OnCreateComponentDescriptor<S> : ComponentDescriptor<S>
+    public class OnCreateComponentDescriptor<S> : ComponentDescriptor<S>
+        where S : class 
 	{
 		private readonly OnCreateActionDelegate<S>[] actions;
 

--- a/src/Castle.Windsor/MicroKernel/Registration/ParametersDescriptor.cs
+++ b/src/Castle.Windsor/MicroKernel/Registration/ParametersDescriptor.cs
@@ -16,7 +16,8 @@ namespace Castle.MicroKernel.Registration
 {
 	using Castle.Core;
 
-	public class ParametersDescriptor<S> : ComponentDescriptor<S>
+    public class ParametersDescriptor<S> : ComponentDescriptor<S>
+        where S : class 
 	{
 		private readonly Parameter[] parameters;
 

--- a/src/Castle.Windsor/MicroKernel/Registration/Proxy/ProxyGroup.cs
+++ b/src/Castle.Windsor/MicroKernel/Registration/Proxy/ProxyGroup.cs
@@ -18,7 +18,8 @@ namespace Castle.MicroKernel.Registration.Proxy
 
 	using Castle.DynamicProxy;
 
-	public class ProxyGroup<S> : RegistrationGroup<S>
+    public class ProxyGroup<S> : RegistrationGroup<S>
+        where S : class 
 	{
 		public ProxyGroup(ComponentRegistration<S> registration)
 			: base(registration)

--- a/src/Castle.Windsor/MicroKernel/Registration/Proxy/ProxyHook.cs
+++ b/src/Castle.Windsor/MicroKernel/Registration/Proxy/ProxyHook.cs
@@ -18,7 +18,8 @@ namespace Castle.MicroKernel.Registration.Proxy
 	using Castle.DynamicProxy;
 	using Castle.MicroKernel.Proxy;
 
-	public class ProxyHook<S> : ComponentDescriptor<S>
+    public class ProxyHook<S> : ComponentDescriptor<S>
+        where S : class 
 	{
 		private readonly IReference<IProxyGenerationHook> hook;
 

--- a/src/Castle.Windsor/MicroKernel/Registration/Proxy/ProxyInterfaces.cs
+++ b/src/Castle.Windsor/MicroKernel/Registration/Proxy/ProxyInterfaces.cs
@@ -18,7 +18,8 @@ namespace Castle.MicroKernel.Registration.Proxy
 	using Castle.Core;
 	using Castle.MicroKernel.Proxy;
 
-	public class ProxyInterfaces<S> : ComponentDescriptor<S>
+    public class ProxyInterfaces<S> : ComponentDescriptor<S>
+        where S : class 
 	{
 		private readonly Type[] interfaces;
 

--- a/src/Castle.Windsor/MicroKernel/Registration/Proxy/ProxyMixIns.cs
+++ b/src/Castle.Windsor/MicroKernel/Registration/Proxy/ProxyMixIns.cs
@@ -19,7 +19,8 @@ namespace Castle.MicroKernel.Registration.Proxy
 	using Castle.Core;
 	using Castle.MicroKernel.Proxy;
 
-	public class ProxyMixIns<S> : ComponentDescriptor<S>
+    public class ProxyMixIns<S> : ComponentDescriptor<S>
+        where S : class 
 	{
 		private readonly MixinRegistration mixIns;
 

--- a/src/Castle.Windsor/MicroKernel/Registration/RegistrationGroup.cs
+++ b/src/Castle.Windsor/MicroKernel/Registration/RegistrationGroup.cs
@@ -15,6 +15,7 @@
 namespace Castle.MicroKernel.Registration
 {
 	public abstract class RegistrationGroup<S>
+        where S : class 
 	{
 		private readonly ComponentRegistration<S> registration;
 

--- a/src/Castle.Windsor/MicroKernel/Registration/ServiceOverrideDescriptor.cs
+++ b/src/Castle.Windsor/MicroKernel/Registration/ServiceOverrideDescriptor.cs
@@ -22,7 +22,8 @@ namespace Castle.MicroKernel.Registration
 	using Castle.Core.Configuration;
 	using Castle.MicroKernel.Util;
 
-	public class ServiceOverrideDescriptor<S> : AbstractPropertyDescriptor<S>
+    public class ServiceOverrideDescriptor<S> : AbstractPropertyDescriptor<S>
+        where S : class 
 	{
 		public ServiceOverrideDescriptor(params ServiceOverride[] overrides)
 			: base(overrides)


### PR DESCRIPTION
Changed class and method declarations to include a generic type parameter constraint of 'class' to prevent value types from being registered as components. Includes Castle.Windsor.Tests\Bugs\IoC-267.cs to test the solution.
