### PR TITLE
IoC-276

### DIFF
--- a/src/Castle.Windsor.Tests/Bugs/IoC-276.cs
+++ b/src/Castle.Windsor.Tests/Bugs/IoC-276.cs
@@ -1,0 +1,37 @@
+﻿using NUnit.Framework;
+
+namespace Castle.Windsor.Tests.Bugs
+{
+	using Castle.Core;
+	using Castle.MicroKernel.Registration;
+
+	[TestFixture]
+	public class IoC_276
+	{
+		[Test]
+		public void can_use_configure_when_using_multiple_based_on_descriptors()
+		{
+			using (var container = new WindsorContainer())
+			{
+				container.Register(AllTypes.FromAssemblyContaining<SomeService>()
+				                   	.BasedOn<A>()
+				                   	.BasedOn<B>()
+				                   	.Configure(registration => registration.LifeStyle.Transient
+				                   	                           	.Named(registration.Implementation.Name.ToLowerInvariant())));
+
+				var handler = container.Kernel.GetHandler(typeof(SomeService));
+
+				Assert.AreEqual("someservice", handler.ComponentModel.Name);
+				Assert.AreEqual(LifestyleType.Transient, handler.ComponentModel.LifestyleType);
+
+			}
+		}
+
+		public interface A{}
+		public interface B{}
+
+		public class SomeService : A,B{}
+	}
+
+
+}

--- a/src/Castle.Windsor.Tests/Castle.Windsor.Tests.csproj
+++ b/src/Castle.Windsor.Tests/Castle.Windsor.Tests.csproj
@@ -341,6 +341,7 @@
   <ItemGroup>
     <Compile Include="AbstractContainerTestCase.cs" />
     <Compile Include="Bugs\IoC-267.cs" />
+    <Compile Include="Bugs\IoC-276.cs" />
     <Compile Include="ByRefDependenciesTestCase.cs" />
     <Compile Include="ClassComponents\CBA.cs" />
     <Compile Include="ClassComponents\GenericHasNested.cs" />


### PR DESCRIPTION
The problem seems to be that the extra configuration gets attached to the last criterion, but FromDescriptor.Register will start with the first one. Reversing the criterion list (simplest solution) caused RemoteSingletonTestCase.WiringRemoteComponent to fail.
