### PR TITLE
Thread safety in IWindsorContainer

### DIFF
--- a/src/Castle.Windsor.Tests/Castle.Windsor.Tests.csproj
+++ b/src/Castle.Windsor.Tests/Castle.Windsor.Tests.csproj
@@ -104,7 +104,7 @@
     <DebugSymbols>true</DebugSymbols>
     <OutputPath>bin\NET35-Debug\</OutputPath>
     <DefineConstants>TRACE;DEBUG;DOTNET DOTNET35</DefineConstants>
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
     <DebugType>full</DebugType>
     <PlatformTarget>AnyCPU</PlatformTarget>
     <CodeAnalysisLogFile>bin\Debug\Castle.Windsor.Tests.dll.CodeAnalysisLog.xml</CodeAnalysisLogFile>
@@ -555,6 +555,7 @@
     <Compile Include="Proxies\InterceptorDependenciesTestCase.cs" />
     <Compile Include="ProxyInfrastructure\OnBehalfAwareInterceptorSelector.cs" />
     <Compile Include="ProxyInfrastructure\OnBehalfAwareProxyGenerationHook.cs" />
+    <Compile Include="Given_a_service_is_registered_with_dependencies.cs" />
     <Compile Include="RegistrationWithAttributeAndXmlTestCase.cs" />
     <Compile Include="RegistrationWithAttributeTestCase.cs" />
     <Compile Include="Components\A.cs" />

--- a/src/Castle.Windsor.Tests/Given_a_service_is_registered_with_dependencies.cs
+++ b/src/Castle.Windsor.Tests/Given_a_service_is_registered_with_dependencies.cs
@@ -1,0 +1,68 @@
+using System.Diagnostics;
+
+namespace Castle.Windsor.Tests
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Threading;
+
+    using Core;
+    using NUnit.Framework;
+
+    public class Given_a_service_is_registered_with_dependencies
+    {
+        private class Class1
+        {}
+
+        private class DependentOnClass1
+        {
+            private readonly Class1 _dependency;
+
+            public DependentOnClass1(Class1 dependency)
+            {
+                _dependency = dependency;
+            }
+        }
+
+        [Test]
+        public void When_registering_services_on_multiple_threads_it_should_not_throw_exceptions()
+        {
+            IWindsorContainer container = new WindsorContainer();
+
+            var threads = new Dictionary<ThreadStart, IAsyncResult>();
+
+            for (int i = 0; i < 500; i++)
+            {
+                var key = Guid.NewGuid().ToString();
+                var key2 = Guid.NewGuid().ToString();
+                ThreadStart t1 = () =>
+                {
+                    container.AddComponentLifeStyle(key, typeof(DependentOnClass1), typeof(DependentOnClass1), LifestyleType.Transient);
+
+                    Thread.Sleep(100);
+
+                    container.AddComponentLifeStyle(key2, typeof(Class1), typeof(Class1), LifestyleType.Transient);
+                };
+
+                var r1 = t1.BeginInvoke(null, null);
+                threads.Add(t1, r1);
+            }
+
+            var exceptionCount = 0;
+            foreach (var kvp in threads)
+            {
+                try
+                {
+                    kvp.Key.EndInvoke(kvp.Value);
+                }
+                catch
+                {
+                    exceptionCount++;
+                }
+            }
+
+            Debug.Print("{0} exceptions raised.", exceptionCount);
+            Assert.AreEqual(0, exceptionCount);
+        }
+    }
+}

--- a/src/Castle.Windsor/MicroKernel/ComponentActivator/AbstractComponentActivator.cs
+++ b/src/Castle.Windsor/MicroKernel/ComponentActivator/AbstractComponentActivator.cs
@@ -16,6 +16,7 @@ namespace Castle.MicroKernel.ComponentActivator
 {
 	using System;
 	using System.Collections.Generic;
+	using System.Linq;
 
 	using Castle.Core;
 	using Castle.MicroKernel.Context;


### PR DESCRIPTION
This pull request includes a test that reproduces the threading bug that was asked about in [this thread](http://groups.google.com/group/castle-project-users/browse_thread/thread/6f6edd7718c411c/8458fca93c8d09bd?lnk=gst&q=mattfenelon#8458fca93c8d09bd) in the Castle Project Users mailing list. 

Unfortunately because the bug is caused by a race condition the test doesn't always fail and it may take a number of runs before it will go red.

What I've noticed is that the IWindsorContainer.Register(Component.For...) methods are locked and as such don't suffer from this problem. Whereas the methods OpenRasta is using, and the methods I'm using in the test, don't include locking. Is this by design?

We are running v2.1.1 of Windsor. My analysis of the problem in that version is: in the situation where you have two components, foo and bar, if foo is registered before bar but has a dependency on bar, it's handler will be set to the waiting dependencies state. If bar is then added, foo will be informed via the RaiseHandlersChanged event, at which point it will remove bar as a waiting dependency. If a second thread is also registering components and raising the RaiseHandlersChanged event, the handler for foo can attempt to remove bar as a waiting dependency twice.

If the test is run against the latest HEAD of the master branch in GitHub it still fails but with a different error. I've not had a chance to track down why it's failing yet.
